### PR TITLE
feat(util): add mask helper

### DIFF
--- a/lib/util/MaskUtil.js
+++ b/lib/util/MaskUtil.js
@@ -1,0 +1,29 @@
+/**
+ * Utility to mask sensitive strings.
+ *
+ * @param {string} str - String to mask.
+ * @param {string} [maskChar='*'] - Mask character.
+ * @param {number} [visibleChars=4] - Number of characters at end to remain visible.
+ *
+ * @return {string} Masked string.
+ */
+export function maskString(str, maskChar = '*', visibleChars = 4) {
+  if (typeof str !== 'string') {
+    return str;
+  }
+
+  const length = str.length;
+
+  if (length <= visibleChars) {
+    return maskChar.repeat(length);
+  }
+
+  const visible = str.slice(-visibleChars);
+  const masked = maskChar.repeat(length - visibleChars);
+
+  return masked + visible;
+}
+
+export default {
+  maskString
+};

--- a/test/spec/util/MaskUtilSpec.js
+++ b/test/spec/util/MaskUtilSpec.js
@@ -1,0 +1,29 @@
+import { maskString } from 'lib/util/MaskUtil';
+
+describe('util/MaskUtil', function() {
+
+  it('should mask all but last 4 chars by default', function() {
+    // when
+    const masked = maskString('1234567890');
+
+    // then
+    expect(masked).to.equal('******7890');
+  });
+
+  it('should allow custom mask character and visible chars', function() {
+    // when
+    const masked = maskString('abcdef', '#', 2);
+
+    // then
+    expect(masked).to.equal('####ef');
+  });
+
+  it('should mask short strings completely', function() {
+    // when
+    const masked = maskString('abc', '*', 4);
+
+    // then
+    expect(masked).to.equal('***');
+  });
+
+});


### PR DESCRIPTION
## Summary
- add `maskString` util to obfuscate sensitive strings
- cover masking util with unit tests

## Testing
- `npm test` *(fails: /root/.cache/puppeteer/chrome/linux-134.0.6998.165/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1257e8c308329a10f12beafd4a09a